### PR TITLE
Fix toggle condition in Controller.

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -16,7 +16,7 @@ parameters:
     # This parameter defines the codes of the locales (languages) enabled in the application
     app_locales: en|fr|de|es|cs|nl|ru|uk|ro|pt_BR|pl|it|ja|id|ca|sl|hr
     app.notifications.email_sender: anonymous@example.com
-    env(FEATURE_COMMENTS_ENABLED): false
+    env(FEATURE_COMMENTS_ENABLED): true
     env(FEATURE_COMMENTS_RESTRICTED): false
 
 # Basic configuration for the Symfony framework features

--- a/src/AppBundle/Controller/BlogController.php
+++ b/src/AppBundle/Controller/BlogController.php
@@ -92,7 +92,9 @@ class BlogController extends Controller
      */
     public function commentNewAction(Request $request, Post $post)
     {
-        if (! $this->getParameter('app.feature_comments')) {
+        if (! $this->getParameter('env(FEATURE_COMMENTS_ENABLED)')
+            || ($this->getParameter('env(FEATURE_COMMENTS_RESTRICTED)') && !$this->isGranted('ROLE_ADMIN'))
+        ) {
             throw $this->createNotFoundException('Page for adding a comment does not exist.');
         }
 


### PR DESCRIPTION
Oops, looks like we forgot to update the conditions we added to the BlogController for making sure adding comments works only when the feature is enabled.